### PR TITLE
Potential fix so that the Negotiation will not just return a "401" and

### DIFF
--- a/jboss-negotiation-common/src/main/java/org/jboss/security/negotiation/NegotiationAuthenticator.java
+++ b/jboss-negotiation-common/src/main/java/org/jboss/security/negotiation/NegotiationAuthenticator.java
@@ -224,7 +224,9 @@ public class NegotiationAuthenticator extends FormAuthenticator
 
       if (principal == null)
       {
-         response.sendError(Response.SC_UNAUTHORIZED);
+         // Instead of returning a 401 here...attempt to fallback to form, otherwise return a 401
+         log.debug("SPNEGO based authentication failed...initiating negotiation");
+         initiateNegotiation(request, response, config);
       }
       else
       {


### PR DESCRIPTION
Potential fix so that the Negotiation will not just return a "401" and
give up in the case where SPNEGO based authentication failed (NTLM, kdc
not available, etc).
[SECURITY-640]
