### PR TITLE
[BZ1086787] LdapExt login module fetches to many attributes in RoleSearch

### DIFF
--- a/jboss-negotiation-extras/src/main/java/org/jboss/security/negotiation/AdvancedLdapLoginModule.java
+++ b/jboss-negotiation-extras/src/main/java/org/jboss/security/negotiation/AdvancedLdapLoginModule.java
@@ -26,6 +26,7 @@ import java.net.URISyntaxException;
 import java.security.Principal;
 import java.security.PrivilegedAction;
 import java.security.acl.Group;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -261,7 +262,22 @@ public class AdvancedLdapLoginModule extends CommonLoginModule
       roleAttributeIsDN = Boolean.parseBoolean(temp);
 
       roleNameAttributeID = (String) options.get(ROLE_NAME_ATTRIBUTE_ID);
-
+      
+      ArrayList<String> roleSearchAttributeList = new ArrayList<String>(3); 
+      if (roleAttributeID != null) 
+      {
+          roleSearchAttributeList.add(roleAttributeID);
+      }
+      if (roleNameAttributeID != null)
+      {
+          roleSearchAttributeList.add(roleNameAttributeID);
+      } 
+      if (referralUserAttributeIDToCheck != null)
+      {
+          roleSearchAttributeList.add(referralUserAttributeIDToCheck);
+      } 
+      roleSearchControls.setReturningAttributes(roleSearchAttributeList.toArray(new String[0]));
+      
       temp = (String) options.get(ALLOW_EMPTY_PASSWORD);
       allowEmptyPassword = Boolean.parseBoolean(temp);
 


### PR DESCRIPTION
component upgrade BZ = https://bugzilla.redhat.com/show_bug.cgi?id=1104269
