### PR TITLE
[SECURITY-897] BZ1236606 Fix NEP when getting respToken if gssToken i…

### DIFF
--- a/jboss-negotiation-spnego/src/main/java/org/jboss/security/negotiation/spnego/SPNEGOLoginModule.java
+++ b/jboss-negotiation-spnego/src/main/java/org/jboss/security/negotiation/spnego/SPNEGOLoginModule.java
@@ -417,24 +417,26 @@ public class SPNEGOLoginModule extends CommonLoginModule
                return Boolean.TRUE;
             }
 
-            byte[] respToken = gssContext.acceptSecContext(gssToken, 0, gssToken.length);
+            if(gssToken != null){
+               byte[] respToken = gssContext.acceptSecContext(gssToken, 0, gssToken.length);
 
-            if (respToken != null)
-            {
-               NegotiationMessage response;
-               if (requestMessage instanceof KerberosMessage)
+               if (respToken != null)
                {
-                  response = new KerberosMessage(Constants.KERBEROS_V5, respToken);
-               }
-               else
-               {
-                  NegTokenTarg negTokenTarg = new NegTokenTarg();
-                  negTokenTarg.setResponseToken(respToken);
+                  NegotiationMessage response;
+                  if (requestMessage instanceof KerberosMessage)
+                  {
+                     response = new KerberosMessage(Constants.KERBEROS_V5, respToken);
+                  }
+                  else
+                  {
+                     NegTokenTarg negTokenTarg = new NegTokenTarg();
+                     negTokenTarg.setResponseToken(respToken);
 
-                  response = negTokenTarg;
-               }
+                     response = negTokenTarg;
+                  }
 
-               negotiationContext.setResponseMessage(response);
+                  negotiationContext.setResponseMessage(response);
+               }
             }
 
             if (gssContext.isEstablished() == false)


### PR DESCRIPTION
…s empty.
https://issues.jboss.org/browse/SECURITY-897
https://bugzilla.redhat.com/show_bug.cgi?id=1236606
If any potential SPNEGOMessage or KerberosMessage has an empty token, trying to get respToken makes a NullPointerException. I only add an extra if() for it.  @darranl Could you review this since you put the " // TODO - Ensure no way to fall through with gssToken still null." I am not quite sure if there is other concern when you added it