### PR TITLE
[SECURITY-922] Store the delegation credentials as part of the session instead of part of the request

### DIFF
--- a/jboss-negotiation-common/src/main/java/org/jboss/security/negotiation/NegotiationAuthenticator.java
+++ b/jboss-negotiation-common/src/main/java/org/jboss/security/negotiation/NegotiationAuthenticator.java
@@ -330,7 +330,7 @@ public class NegotiationAuthenticator extends FormAuthenticator
                try
                {
                   GSSCredential delegCredential = gssContext.getDelegCred();
-                  request.setNote(DELEGATION_CREDENTIAL, delegCredential);
+                  session.setNote(DELEGATION_CREDENTIAL, delegCredential);
                }
                catch (GSSException e)
                {
@@ -483,7 +483,7 @@ public class NegotiationAuthenticator extends FormAuthenticator
 
       public void invoke(Request request, Response response) throws IOException, ServletException
       {
-         GSSCredential credential = (GSSCredential) request.getNote(DELEGATION_CREDENTIAL);
+         GSSCredential credential = (GSSCredential) request.getSessionInternal(false).getNote(DELEGATION_CREDENTIAL);
          try
          {
             DelegationCredentialManager.setDelegationCredential(credential);


### PR DESCRIPTION
BZ:  https://bugzilla.redhat.com/show_bug.cgi?id=1267738

Upstream: https://issues.jboss.org/browse/SECURITY-922

This fix does not need to be put into master since it was implemented a different way in master (due to undertow I believe).   See SECURITY-910.