### PR TITLE
auth-method in web.xml must be written in capital letters

### DIFF
--- a/jboss-negotiation-toolkit/src/main/webapp/WEB-INF/web.xml
+++ b/jboss-negotiation-toolkit/src/main/webapp/WEB-INF/web.xml
@@ -71,7 +71,7 @@
     </security-constraint>
     
    <login-config>   
-    <auth-method>SPNEGO,Form</auth-method>
+    <auth-method>SPNEGO,FORM</auth-method>
     <realm-name>SPNEGO</realm-name>
     <form-login-config>
       <form-login-page>/login.html</form-login-page>


### PR DESCRIPTION
 * deployment on wildfly 10 fails with the message: UT010039: Unknown authentication mechanism Form