### PR TITLE
[SECURITY-933] The root cause of login module failures gets lost (2.3.x)

### DIFF
--- a/jboss-negotiation-extras/src/main/java/org/jboss/security/negotiation/AdvancedLdapLoginModule.java
+++ b/jboss-negotiation-extras/src/main/java/org/jboss/security/negotiation/AdvancedLdapLoginModule.java
@@ -328,6 +328,10 @@ public class AdvancedLdapLoginModule extends CommonLoginModule
 
       if (result instanceof LoginException)
       {
+         if (log.isDebugEnabled())
+         {
+            log.debug("Login failed", (LoginException) result);
+         }
          throw (LoginException) result;
       }
 


### PR DESCRIPTION
...when multiple login modules are stacked

https://bugzilla.redhat.com/show_bug.cgi?id=1288668
https://issues.jboss.org/browse/SECURITY-933

Upstream PR: https://github.com/wildfly-security/jboss-negotiation/pull/27