### PR TITLE
[SECURITY-933] The root cause of login module failures gets lost (master)

### DIFF
--- a/jboss-negotiation-extras/src/main/java/org/jboss/security/negotiation/AdvancedLdapLoginModule.java
+++ b/jboss-negotiation-extras/src/main/java/org/jboss/security/negotiation/AdvancedLdapLoginModule.java
@@ -328,6 +328,10 @@ public class AdvancedLdapLoginModule extends CommonLoginModule
 
       if (result instanceof LoginException)
       {
+         if (log.isDebugEnabled())
+         {
+            log.debug("Login failed", (LoginException) result);
+         }
          throw (LoginException) result;
       }
 


### PR DESCRIPTION
...when multiple login modules are stacked

https://issues.jboss.org/browse/JBEAP-2817
https://issues.jboss.org/browse/SECURITY-933