### PR TITLE
SECURITY-934 - RolesSearch in AdvancedLdapLoginModule is doing a needless LDAP call for each individual role

### DIFF
--- a/jboss-negotiation-extras/src/main/java/org/jboss/security/negotiation/AdvancedLdapLoginModule.java
+++ b/jboss-negotiation-extras/src/main/java/org/jboss/security/negotiation/AdvancedLdapLoginModule.java
@@ -800,9 +800,11 @@ public class AdvancedLdapLoginModule extends CommonLoginModule
       {roleAttributeID};
 
       Attributes result = null;
-      if (sr == null || sr.isRelative())
-      {
-         result = searchContext.getAttributes(dn, attrNames);
+      if (sr == null || ( sr.isRelative() && sr.getAttributes().size() == 0 ) ) {
+          result = searchContext.getAttributes(dn, attrNames);
+      }
+      else if (sr != null && sr.isRelative() && sr.getAttributes().size() != 0 ) {
+          result = sr.getAttributes();
       }
       else
       {


### PR DESCRIPTION
This is a fix proposal for [SECURITY-934](https://issues.jboss.org/browse/SECURITY-934). There is sadly no easy to test it, but it does follow the same logic as the fix implemented [BZ1223840](https://bugzilla.redhat.com/show_bug.cgi?id=1223840) - see [PR36](https://github.com/picketbox/picketbox/pull/36), for more details - which boils down to checking if the attributes fields does not already contains the informations on roles.

I would also like to backport this changes to the maintenance for EAP7, to resolved the associated issue, [JBEAP-3013](https://issues.jboss.org/browse/JBEAP-3013), but I could not find a branch matching the 3.0.2 released (I'm guessing, maybe there is not such a branch for now).

_Disclaimer: I'm far from being a LDAP expert, I am even probably the opposite of that, as Tom Fonteyn can probably testify. So please do review this changes carefully before merging it. And, of course, let me know if you want me to change or enhance my fix._