### PR TITLE
[JBEAP-4394][SECURITY-921] SPNEGO authentication fails on Windows-KDC

### DIFF
--- a/jboss-negotiation-spnego/src/main/java/org/jboss/security/negotiation/spnego/SPNEGOLoginModule.java
+++ b/jboss-negotiation-spnego/src/main/java/org/jboss/security/negotiation/spnego/SPNEGOLoginModule.java
@@ -23,6 +23,7 @@
 package org.jboss.security.negotiation.spnego;
 
 import static org.jboss.security.negotiation.Constants.KERBEROS_V5;
+import static org.jboss.security.negotiation.Constants.KERBEROS_V5_LEGACY;
 
 import java.security.Principal;
 import java.security.PrivilegedAction;
@@ -87,6 +88,8 @@ public class SPNEGOLoginModule extends CommonLoginModule
    private static final String SPNEGO = "SPNEGO";
 
    private static final Oid kerberos = KERBEROS_V5;
+
+   private static final Oid legacyKerberos = KERBEROS_V5_LEGACY;
 
    /*
     * Configuration Options
@@ -368,7 +371,7 @@ public class SPNEGOLoginModule extends CommonLoginModule
                NegTokenInit negTokenInit = (NegTokenInit) requestMessage;
                List<Oid> mechList = negTokenInit.getMechTypes();
 
-               if (mechList.get(0).equals(kerberos))
+               if (mechList.get(0).equals(kerberos) || mechList.get(0).equals(legacyKerberos))
                {
                   gssToken = negTokenInit.getMechToken();
                }


### PR DESCRIPTION
EAP 7.0: https://issues.jboss.org/browse/JBEAP-4394
EAP 7.1: https://issues.jboss.org/browse/JBEAP-9334
SECURITY: https://issues.jboss.org/browse/SECURITY-921

When client sends negotiation token for MechType = [LegacyKerberos, Kerberos], it gets 401 Unauthorized and must do additional request. While no problem for browsers, when authenticating through code or REST client, this is serious obstacle.

This PR should fix the issue by allowing legacy kerberos mech type to be accepted as well.