### PR TITLE
Fix for JBEAP-11680: Kerberos negotiation done in every request

### DIFF
--- a/jboss-negotiation-common/src/main/java/org/jboss/security/negotiation/NegotiationMechanism.java
+++ b/jboss-negotiation-common/src/main/java/org/jboss/security/negotiation/NegotiationMechanism.java
@@ -96,7 +96,7 @@ public class NegotiationMechanism implements AuthenticationMechanism {
                         AuthenticatedSessionManager.AuthenticatedSession authSession = sessionManager.lookupSession(exchange);
                         if (authSession != null) {
                             account = authSession.getAccount();
-                            if (account != null || account.getPrincipal() != null) {
+                            if (account != null && account.getPrincipal() != null) {
                                 negContext.setUsername(account.getPrincipal().getName());
                             }
                         }

--- a/jboss-negotiation-common/src/main/java/org/jboss/security/negotiation/NegotiationMechanism.java
+++ b/jboss-negotiation-common/src/main/java/org/jboss/security/negotiation/NegotiationMechanism.java
@@ -21,6 +21,7 @@ import static io.undertow.util.Headers.AUTHORIZATION;
 import static io.undertow.util.Headers.NEGOTIATE;
 import static io.undertow.util.Headers.WWW_AUTHENTICATE;
 import static io.undertow.util.StatusCodes.UNAUTHORIZED;
+import io.undertow.security.api.AuthenticatedSessionManager;
 import io.undertow.security.api.AuthenticationMechanism;
 import io.undertow.security.api.SecurityContext;
 import io.undertow.security.idm.Account;
@@ -89,6 +90,18 @@ public class NegotiationMechanism implements AuthenticationMechanism {
                         return AuthenticationMechanismOutcome.NOT_AUTHENTICATED;
                     }
 
+                    Account account = null;
+                    AuthenticatedSessionManager sessionManager = (AuthenticatedSessionManager)exchange.getAttachment(AuthenticatedSessionManager.ATTACHMENT_KEY);
+                    if (sessionManager != null) {
+                        AuthenticatedSessionManager.AuthenticatedSession authSession = sessionManager.lookupSession(exchange);
+                        if (authSession != null) {
+                            account = authSession.getAccount();
+                            if (account != null || account.getPrincipal() != null) {
+                                negContext.setUsername(account.getPrincipal().getName());
+                            }
+                        }
+                    }
+
                     String username = negContext.getUsername();
                     if (username == null || username.length() == 0) {
                         username = UUID.randomUUID().toString();
@@ -98,7 +111,11 @@ public class NegotiationMechanism implements AuthenticationMechanism {
                     IdentityManager identityManager = getIdentityManager(securityContext);
                     try {
                         negContext.associate();
-                        final Account account = identityManager.verify(username, null);
+                        if (account != null) {
+                            account = identityManager.verify(account);
+                        } else {
+                            account = identityManager.verify(username, null);
+                        }
                         if (account != null) {
                             securityContext.authenticationComplete(account, "SPNEGO", true);
 


### PR DESCRIPTION
Hi,

Tentative patch for the bug [11680: Kerberos negotiation done in every request](https://issues.jboss.org/browse/JBEAP-11680). The idea is searching the account in the session manager and, if found, using this account instead of a new created with a new UUID. In turn the authentication manager finds the account in the cache and no negotiation is done.

Please review the patch cos I don't know the code of jboss-negotiation in detail.

Thanks in advance!